### PR TITLE
Correção de dois bugs e melhoria no segundo passo do formulário (endereço).

### DIFF
--- a/mocks/db.json
+++ b/mocks/db.json
@@ -35,45 +35,6 @@
       "neightborhood": "Centro",
       "street": "Primeira Rua de Teste",
       "number": "333"
-    },
-    {
-      "name": "Clínica 05",
-      "cpf": "11793994633",
-      "socialCapital": "12345",
-      "cep": "01001000",
-      "state": "SP",
-      "city": "São Paulo",
-      "neightborhood": "Sé",
-      "street": "Praça da Sé",
-      "number": "01",
-      "complement": "",
-      "id": 4
-    },
-    {
-      "name": "Clínica 06",
-      "cpf": "00000000191",
-      "socialCapital": "123",
-      "cep": "01001000",
-      "state": "SP",
-      "city": "São Paulo",
-      "neightborhood": "Sé",
-      "street": "Praça da Sé",
-      "number": "01",
-      "complement": "",
-      "id": 5
-    },
-    {
-      "name": "Clínica 07",
-      "cpf": "11793994633",
-      "socialCapital": "16444",
-      "cep": "38500000",
-      "state": "MG",
-      "city": "Monte Carmelo",
-      "neightborhood": "Centro",
-      "street": "Rua Aureliano Rocha ",
-      "number": "1999",
-      "complement": "Bloco 1 apto 204",
-      "id": 6
     }
   ]
 }

--- a/mocks/db.json
+++ b/mocks/db.json
@@ -35,6 +35,45 @@
       "neightborhood": "Centro",
       "street": "Primeira Rua de Teste",
       "number": "333"
+    },
+    {
+      "name": "Clínica 05",
+      "cpf": "11793994633",
+      "socialCapital": "12345",
+      "cep": "01001000",
+      "state": "SP",
+      "city": "São Paulo",
+      "neightborhood": "Sé",
+      "street": "Praça da Sé",
+      "number": "01",
+      "complement": "",
+      "id": 4
+    },
+    {
+      "name": "Clínica 06",
+      "cpf": "00000000191",
+      "socialCapital": "123",
+      "cep": "01001000",
+      "state": "SP",
+      "city": "São Paulo",
+      "neightborhood": "Sé",
+      "street": "Praça da Sé",
+      "number": "01",
+      "complement": "",
+      "id": 5
+    },
+    {
+      "name": "Clínica 07",
+      "cpf": "11793994633",
+      "socialCapital": "16444",
+      "cep": "38500000",
+      "state": "MG",
+      "city": "Monte Carmelo",
+      "neightborhood": "Centro",
+      "street": "Rua Aureliano Rocha ",
+      "number": "1999",
+      "complement": "Bloco 1 apto 204",
+      "id": 6
     }
   ]
 }

--- a/src/components/ui/DetailAccordion/index.jsx
+++ b/src/components/ui/DetailAccordion/index.jsx
@@ -18,17 +18,18 @@ const DetailAccordion = ({ summary, go, details, className, defaultExpanded }) =
           <div className="w-100">
             {details.map((data, index) => {
               const objKey = Object.keys(data)[0];
-              const objValue = data[Object.keys(data)[0]];
+              const objValue = data[objKey];
 
-              return (
-                <ListItemText
-                  key={index}
-                  primaryTypographyProps={{ style: { fontSize: 13 } }}
-                >
-                  {`${objKey}: ${objValue}`}
-                </ListItemText>
-              )
-
+              if(objValue) {
+                return (
+                  <ListItemText
+                    key={index}
+                    primaryTypographyProps={{ style: { fontSize: 13 } }}
+                  >
+                    {`${objKey}: ${objValue}`}
+                  </ListItemText>
+                );
+              }
             })}
             <div className="flex justify-end items-center">
               <IconButton

--- a/src/pages/Clinic/Add/components/Confirm/index.jsx
+++ b/src/pages/Clinic/Add/components/Confirm/index.jsx
@@ -39,7 +39,7 @@ const Confirm = ({
     <>
       <h2 className="mt12 f20">Revisar Dados</h2>
       <h4 className="mt12 mb24 f14 fw3 gray">Clique no lápis para editar</h4>
-      <DetailAccordion defaultExpanded={true} className="mt16 ba br2 shadow-4 b--black-10" summary="Sobre a Clínica" go={go} details={[
+      <DetailAccordion defaultExpanded={true} className="mt16 ba br2 shadow-4 b--black-10" summary="Sobre" go={go} details={[
         { 'Nome da clínica': name },
         { 'CPF do responsável': cpfLib.format(cpf) },
         { 'Capital social': formatMoney(socialCapital) },

--- a/src/pages/Clinic/Add/components/FirstStep/index.jsx
+++ b/src/pages/Clinic/Add/components/FirstStep/index.jsx
@@ -1,10 +1,9 @@
 import PropTypes from 'prop-types';
 import { Form, Formik } from "formik";
-import * as yup from 'yup';
-import { cpf as cpfValidator } from 'cpf-cnpj-validator';
 
 import Input from 'components/ui/Input';
 import Button from 'components/ui/Button';
+import validationSchema from './utils/validationSchema';
 
 const FirstStep = ({
   formData,
@@ -12,25 +11,13 @@ const FirstStep = ({
   navigation
 }) => {
 
-  const validate = yup.object({
-    name: yup.string()
-      .max(100, 'Deve ter no máximo 100 caracteres!')
-      .required('Campo obrigatório!'),
-    cpf: yup.string()
-      .required('Campo obrigatório!')
-      .test('cpf-validation', 'Número Inválido!', value => cpfValidator.isValid(value)),
-    socialCapital: yup.string()
-      .required('Campo obrigatório!')
-      .test('money-validation', 'Valor inválido!', value => !isNaN(+value))
-  });
-
   return (
     <>
       <h2 className="mt12 mb24 f20">Sobre a Clínica</h2>
 
       <Formik
         initialValues={formData}
-        validationSchema={validate}
+        validationSchema={validationSchema}
         onSubmit={async values => {
           await Object.keys(values).map(key => {
             const formTarget = {

--- a/src/pages/Clinic/Add/components/FirstStep/utils/validationSchema.js
+++ b/src/pages/Clinic/Add/components/FirstStep/utils/validationSchema.js
@@ -1,0 +1,16 @@
+import { cpf as cpfValidator } from 'cpf-cnpj-validator';
+import * as yup from 'yup';
+
+const validationSchema = yup.object({
+  name: yup.string()
+    .max(100, 'Deve ter no máximo 100 caracteres!')
+    .required('Campo obrigatório!'),
+  cpf: yup.string()
+    .required('Campo obrigatório!')
+    .test('cpf-validation', 'Número Inválido!', value => cpfValidator.isValid(value)),
+  socialCapital: yup.string()
+    .required('Campo obrigatório!')
+    .test('money-validation', 'Valor inválido!', value => !isNaN(+value))
+});
+
+export default validationSchema;

--- a/src/pages/Clinic/Add/components/SecondStep/index.jsx
+++ b/src/pages/Clinic/Add/components/SecondStep/index.jsx
@@ -1,12 +1,13 @@
+import { useState } from "react";
 import { Form, Formik } from "formik";
-import * as yup from 'yup';
 import Loader from 'react-loader-spinner';
 import PropTypes from 'prop-types';
+
 import Input from 'components/ui/Input';
 import Button from 'components/ui/Button';
-
 import { searchCep } from './requests';
-import { useState } from "react";
+import validateSchema from "./utils/validationSchema";
+import apiRelationToFormFields from "./utils/apiRelationToFormFields";
 
 const SecondStep = ({
   formData,
@@ -14,21 +15,6 @@ const SecondStep = ({
   navigation
 }) => {
   const [displaySpinner, setDisplaySpinner] = useState(false);
-
-  const validate = yup.object({
-    cep: yup
-      .string()
-      .required('CEP obrigatório')
-      .min(8, 'O CEP contém 8 digitos')
-      .max(8, 'O CEP contém 8 digitos'),
-    state: yup.string().required('Campo obrigatório')
-      .max(2, 'A UF tem no máximo 2 letras!'),
-    city: yup.string().required('Campo obrigatório'),
-    street: yup.string().required('Campo obrigatório'),
-    number: yup.string().required('Campo obrigatório'),
-    neightborhood: yup.string().required('Campo obrigatório'),
-    complement: yup.string(),
-  });
 
   const handleCepBlur = async (ev, setFieldValue, setFieldError) => {
     const { value } = ev.target;
@@ -45,19 +31,11 @@ const SecondStep = ({
               setFieldError("cep", "Valor não encontrado!");
             }
             else {
-              const relation = {
-                cep: "cep",
-                state: "uf",
-                city: "localidade",
-                street: "logradouro",
-                neightborhood: "bairro",
-              };
-
               Object.keys(data).forEach(key => {
                 const apiResponseValue = data[key];
 
                 if (apiResponseValue) {
-                  const fieldName = Object.keys(relation).filter(rk => relation[rk] === key)[0];
+                  const fieldName = Object.keys(apiRelationToFormFields).filter(rk => apiRelationToFormFields[rk] === key)[0];
 
                   if (fieldName) {
                     const isCepField = fieldName === "cep";
@@ -65,20 +43,13 @@ const SecondStep = ({
                     if (!isCepField) {
                       setFieldValue(fieldName, apiResponseValue);
                     }
-
-                    setForm({
-                      target: {
-                        name: fieldName,
-                        value: isCepField ? value : apiResponseValue,
-                      }
-                    });
                   }
                 }
               });
             }
           })
           .catch(error => {
-
+            alert(error);
           })
           .finally(() => {
             setDisplaySpinner(false);
@@ -104,7 +75,7 @@ const SecondStep = ({
 
       <Formik
         initialValues={formData}
-        validationSchema={validate}
+        validationSchema={validateSchema}
         onSubmit={async values => {
           await Object.keys(values).map(key => {
             const formTarget = {

--- a/src/pages/Clinic/Add/components/SecondStep/utils/apiRelationToFormFields.js
+++ b/src/pages/Clinic/Add/components/SecondStep/utils/apiRelationToFormFields.js
@@ -1,0 +1,9 @@
+const apiRelationToFormFields = {
+  cep: "cep",
+  state: "uf",
+  city: "localidade",
+  street: "logradouro",
+  neightborhood: "bairro",
+};
+
+export default apiRelationToFormFields;

--- a/src/pages/Clinic/Add/components/SecondStep/utils/validationSchema.js
+++ b/src/pages/Clinic/Add/components/SecondStep/utils/validationSchema.js
@@ -1,0 +1,18 @@
+import * as yup from 'yup';
+
+const validateSchema = yup.object({
+  cep: yup
+    .string()
+    .required('CEP obrigatório')
+    .min(8, 'O CEP contém 8 digitos')
+    .max(8, 'O CEP contém 8 digitos'),
+  state: yup.string().required('Campo obrigatório')
+    .max(2, 'A UF tem no máximo 2 letras!'),
+  city: yup.string().required('Campo obrigatório'),
+  street: yup.string().required('Campo obrigatório'),
+  number: yup.string().required('Campo obrigatório'),
+  neightborhood: yup.string().required('Campo obrigatório'),
+  complement: yup.string(),
+});
+
+export default validateSchema;

--- a/src/pages/Clinic/List/index.jsx
+++ b/src/pages/Clinic/List/index.jsx
@@ -33,6 +33,7 @@ const Clinic = () => {
         })
         .catch(error => {
           setClinics([]);
+          alert(error);
         })
         .finally(() => {
           setShowLoadingSpinner(false);
@@ -93,7 +94,7 @@ const Clinic = () => {
                     socialCapital: formatMoney(socialCapital),
                     cep: formatCep(cep),
                     location: `${city}/${state}`,
-                    address: `${street}, ${neightborhood} - ${number} ${complement ?? ""}`
+                    address: `${street}, ${number} - ${neightborhood} ${complement ? ` (${complement})` : ""}`
                   })}
                 />
               </div>


### PR DESCRIPTION
Após realizar um último teste na versão enviada na branch "cc/feature/iclinic" foi constado os seguintes problemas que foram ajustados:

### Melhoria para que os campos autocompletados pelo cep permaneçam informados ao voltar para o primeiro passo
- Ao preencher o campo CEP, os campos autocompletados permaneciam preenchidos após o usuário clicar no botão "Voltar" e depois retornar novamente para o segundo passo. Isso foi alterado para que o campo de CEP não realize este comportamento.

### Correção do bug ao clicar no ícone de editar os campos "Sobre a clínica" no terceiro passo do formulário.
- Como podemos ver através deste [print](https://prnt.sc/1upad45), a aplicação quebrava pois não encontrava o passo nomeado como "sobre a clínica". Isso se deve ao fato do primeiro passo estar nomeado como apenas "sobre", na qual apenas retirar o sufixo destacado no print foi o sufisciente para corrigir o bug.

### Correção na listagem de complemento no terceiro passo do formulário
- Como exemplificado neste [print](https://prnt.sc/1upa80v), caso o campo "Complemento" não fosse informado no passo anterior, no terceiro passo ele era exibido com um valor em branco a seguir. Isso foi corrigido para que um campo do formulário não seja listado caso seu valor não for informado.

Além disso, foi realizadas outras melhoridas gerais no código:
- Melhoria na listagem da coluna "Endereço" na tabela de clínicas.
- Extração do objeto de validação yup para um arquivo de utils relativo ao componente do formulário.